### PR TITLE
Use int32 for QuestionStatus in graphql schema. 

### DIFF
--- a/prototype/Cargo.lock
+++ b/prototype/Cargo.lock
@@ -1263,9 +1263,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "sudodb"
-version = "0.4.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfdc4d541ff6ca25653af4853468d3d4cca39307ce2b1dacedc258193e19254"
+checksum = "a1421e70f9101fefb950ec882e07d0588487d42cf1c54af0bd733980053045ee"
 dependencies = [
  "base32",
  "chrono",
@@ -1277,9 +1277,9 @@ dependencies = [
 
 [[package]]
 name = "sudograph"
-version = "0.4.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4905b521191a1b1ee1dd1cb93fdb046a5fc3f6f586e4c7267f95fb3efcb6a11f"
+checksum = "ec88784a95f1b8061bf5b7e4b34dadcefd5e18dbe7f194b729790c4deb327bb1"
 dependencies = [
  "async-graphql",
  "getrandom",
@@ -1295,9 +1295,9 @@ dependencies = [
 
 [[package]]
 name = "sudograph-generate"
-version = "0.4.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b914d839ae5c89df4897c391857cc5c0232d8eed611a5d0b8fed03c43fa74df"
+checksum = "1bab490b516032e4fba0a87c28b0b70066489ca2b0bcb176c85c794e92e8a56c"
 dependencies = [
  "graphql-parser",
  "proc-macro2",

--- a/prototype/canisters/graphql/Cargo.toml
+++ b/prototype/canisters/graphql/Cargo.toml
@@ -8,7 +8,7 @@ path = "src/graphql.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-sudograph = "0.4.3"
+sudograph = "0.3.0"
 serde_json = "1.0.64"
 serde = "1.0.126"
 ic-cdk = "0.3.0"

--- a/prototype/canisters/graphql/src/queries/close_question.rs
+++ b/prototype/canisters/graphql/src/queries/close_question.rs
@@ -4,7 +4,7 @@ pub mod macros{
         () => {
             r#"mutation ($question_id: ID!, $close_transaction_block_height: String!, $status_update_date: Int!) {
               updateQuestion(
-                input: {id: $question_id, close_transaction_block_height: $close_transaction_block_height, status_update_date: $status_update_date, status: CLOSED}
+                input: {id: $question_id, close_transaction_block_height: $close_transaction_block_height, status_update_date: $status_update_date, status: 4}
               ) {
                 id
                 author {

--- a/prototype/canisters/graphql/src/queries/create_question.rs
+++ b/prototype/canisters/graphql/src/queries/create_question.rs
@@ -4,7 +4,7 @@ pub mod macros {
         () => {
             r#"mutation ($author_id: ID!, $invoice_id: ID!, $creation_date: Int!, $status_end_date: Int!, $open_duration: Int!, $title: String!, $content: String!, $reward: Int!) {
               createQuestion(
-                input: {author: {connect: $author_id}, author_invoice: {connect: $invoice_id}, creation_date: $creation_date, status: OPEN, status_update_date: $creation_date, status_end_date: $status_end_date, open_duration: $open_duration, title: $title, content: $content, reward: $reward}
+                input: {author: {connect: $author_id}, author_invoice: {connect: $invoice_id}, creation_date: $creation_date, status: 0, status_update_date: $creation_date, status_end_date: $status_end_date, open_duration: $open_duration, title: $title, content: $content, reward: $reward}
               ) {
                 id
                 author {

--- a/prototype/canisters/graphql/src/queries/must_pick_answer.rs
+++ b/prototype/canisters/graphql/src/queries/must_pick_answer.rs
@@ -3,7 +3,7 @@ pub mod macros{
     macro_rules! mutation{
         () => {
             r#"mutation ($question_id: ID!, $status_update_date: Int!, $status_end_date: Int!) {
-              updateQuestion(input: {id: $question_id, status_update_date: $status_update_date, status_end_date: $status_end_date, status: PICKANSWER}) {
+              updateQuestion(input: {id: $question_id, status_update_date: $status_update_date, status_end_date: $status_end_date, status: 1}) {
                 id
                 author {
                   id

--- a/prototype/canisters/graphql/src/queries/open_dispute.rs
+++ b/prototype/canisters/graphql/src/queries/open_dispute.rs
@@ -4,7 +4,7 @@ pub mod macros{
         () => {
             r#"mutation ($question_id: ID!, $status_update_date: Int!) {
               updateQuestion(
-                input: {id: $question_id, status_update_date: $status_update_date, status: DISPUTED}
+                input: {id: $question_id, status_update_date: $status_update_date, status: 3}
               ) {
                 id
                 author {

--- a/prototype/canisters/graphql/src/queries/pick_winner.rs
+++ b/prototype/canisters/graphql/src/queries/pick_winner.rs
@@ -3,7 +3,7 @@ pub mod macros{
     macro_rules! mutation{
         () => {
             r#"mutation ($question_id: ID!, $answer_id: ID!, $status_update_date: Int!, $status_end_date: Int!) {
-              updateQuestion(input: {id: $question_id, winner: {connect: $answer_id}, status_update_date: $status_update_date, status_end_date: $status_end_date, status: DISPUTABLE}) {
+              updateQuestion(input: {id: $question_id, winner: {connect: $answer_id}, status_update_date: $status_update_date, status_end_date: $status_end_date, status: 2}) {
                 id
                 author {
                   id

--- a/prototype/canisters/graphql/src/queries/solve_dispute.rs
+++ b/prototype/canisters/graphql/src/queries/solve_dispute.rs
@@ -3,7 +3,7 @@ pub mod macros{
     macro_rules! mutation{
         () => {
             r#"mutation ($question_id: ID!, $answer_id: ID!, $close_transaction_block_height: String!, $status_update_date: Int!) {
-              updateQuestion(input: {id: $question_id, winner: {connect: $answer_id}, close_transaction_block_height: $close_transaction_block_height, status_update_date: $status_update_date, status: CLOSED}) {
+              updateQuestion(input: {id: $question_id, winner: {connect: $answer_id}, close_transaction_block_height: $close_transaction_block_height, status_update_date: $status_update_date, status: 4}) {
                 id
                 author {
                   id

--- a/prototype/canisters/graphql/src/schema.graphql
+++ b/prototype/canisters/graphql/src/schema.graphql
@@ -1,18 +1,11 @@
 type SudographSettings {
     exportGeneratedMutationFunction: true
+    exportGeneratedPostUpgradeFunction: false
 }
 
 type Admin {
     id: ID! # Auto-generated
     principal: String!
-}
-
-enum QuestionStatus {
-    OPEN
-    PICKANSWER
-    DISPUTABLE
-    DISPUTED
-    CLOSED
 }
 
 type User {
@@ -35,7 +28,7 @@ type Question {
     author: User! @relation(name: "User:questions::Question:author")
     author_invoice: Invoice!
     creation_date: Int!
-    status: QuestionStatus!
+    status: Int!
     status_update_date: Int!
     status_end_date: Int!
     open_duration: Int!


### PR DESCRIPTION
After rethinking it, I think I managed to limit the change to the rust canister, so no change is required in Motoko/front-end.

It compiles, but I haven't tested yet. There is a risk that the hardcoded status in the rust queries files do not have the right syntax.